### PR TITLE
Update resolved bunyan version

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -579,10 +579,10 @@ doctrine@^2.0.0:
     isarray "^1.0.0"
 
 dtrace-provider@~0.8:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/dtrace-provider/-/dtrace-provider-0.8.1.tgz#cd4d174a233bea1bcf4a1fbfa5798f44f48cda9f"
+  version "0.8.7"
+  resolved "https://registry.yarnpkg.com/dtrace-provider/-/dtrace-provider-0.8.7.tgz#dc939b4d3e0620cfe0c1cd803d0d2d7ed04ffd04"
   dependencies:
-    nan "^2.3.3"
+    nan "^2.10.0"
 
 ecc-jsbn@~0.1.1:
   version "0.1.1"
@@ -1756,9 +1756,9 @@ mv@~2:
     ncp "~2.0.0"
     rimraf "~2.4.0"
 
-nan@^2.3.3:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.5.1.tgz#d5b01691253326a97a2bbee9e61c55d8d60351e2"
+nan@^2.10.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
 
 natural-compare@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
Debugnyan depends on bunyan `^1.8.1`, which is resolved by yarn.lock to `1.8.9`.

Bunyan depends on dtrace-provider `~0.8`, which is resolved by debugnyan's yarn.lock to `0.8.1`.

That version of dtrace-provider is not compatible with node 10. The fix has only been added to version `0.8.7`.

Version `~0.8` also resolves to `0.8.7`, so there's no need to change the dependency version. We only need to update yarn's resolved version to have the newest dtrace-provider version available to debugnyan and its dependents.

This PR's diff can be reviewed by deleting yarn.lock, running `yarn` again and checking the resolved version of `dtrace-provider` (and its dependency `nan`) is exactly the same as the one in this diff.