### PR TITLE
Fix debug level option

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ module.exports = function debugnyan(name, options, {
   const [root] = components;
 
   if (!loggers[root]) {
-    loggers[root] = bunyan.createLogger(Object.assign({}, options, { level, name: root }));
+    loggers[root] = bunyan.createLogger(Object.assign({ level }, options, { name: root }));
   }
 
   let child = loggers[root];
@@ -47,18 +47,13 @@ module.exports = function debugnyan(name, options, {
       continue;
     }
 
-    options = Object.assign({}, options, {
-      [`${prefix.repeat(i - 1)}${suffix}`]: current,
-      level
-    });
-
+    options = Object.assign({ level }, options, { [`${prefix.repeat(i - 1)}${suffix}`]: current });
     child = next.child(options, simple);
-
     loggers[childName] = child;
   }
 
   if (debug.enabled(name)) {
-    child.level(bunyan.DEBUG);
+    child.level(level);
   }
 
   return loggers[name];

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -28,6 +28,12 @@ describe('debugnyan', () => {
     expect(logger.level()).toEqual(Logger.FATAL + 1);
   });
 
+  it('should allow customizing the logging level', () => {
+    const logger = debugnyan('bar', { level: Logger.INFO });
+
+    expect(logger.level()).toEqual(Logger.INFO);
+  });
+
   it('should accept a dictionary of options', () => {
     const logger = debugnyan('biz', { bar: 'qux', biz: 'net' });
 


### PR DESCRIPTION
This PR fixes the `debugnyan` debug `level` option. 

The current version always replaces the given `level` option by the default value and therefore does not allow to set a custom level.