### PR TITLE
Fix version on changelog script

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "url": "https://github.com/uphold/debugnyan.git"
   },
   "scripts": {
-    "changelog": "uphold-scripts changelog v$npm_package_version",
+    "changelog": "uphold-scripts changelog $npm_package_version",
     "lint": "uphold-scripts lint",
     "release": "uphold-scripts release",
     "test": "uphold-scripts test",


### PR DESCRIPTION
The changelog script is generating a wrong link to the tag.

```
## [v3.0.0](https://github.com/uphold/debugnyan/releases/tag/vv3.0.0) (2021-09-17)
```

It seems there's no way to have a single `v` on both sides (version/url tag) until https://github.com/uphold/uphold-scripts/pull/33 is merged.