### PR TITLE
Add support for omitting the options param

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 import Logger from 'bunyan';
 
-declare function debugnyan(name: string, options: Partial<Logger.LoggerOptions>, { prefix, simple, suffix }?: {
+declare function debugnyan(name: string, options?: Partial<Logger.LoggerOptions>, { prefix, simple, suffix }?: {
     prefix?: string;
     simple?: boolean;
     suffix?: string;

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ const level = bunyan.FATAL + 1;
  * Export `debugnyan`.
  */
 
-module.exports = function debugnyan(name, options, { prefix = 'sub', simple = true, suffix = 'component' } = {}) {
+module.exports = function debugnyan(name, options = {}, { prefix = 'sub', simple = true, suffix = 'component' } = {}) {
   const [root, ...components] = name.split(':');
 
   if (!loggers[root]) {


### PR DESCRIPTION
Currently, typescript forces to pass an empty object when no options are specified. This PR makes the options optional.